### PR TITLE
Log to stdout by default.

### DIFF
--- a/10.4/ansible/templates/my.cnf.d/flight-deck.cnf.j2
+++ b/10.4/ansible/templates/my.cnf.d/flight-deck.cnf.j2
@@ -3,3 +3,4 @@ max_allowed_packet = {{ mysql_max_allowed_packet | default('64M') }}
 query_cache_size = {{ mysql_query_cache_size | default('0') }}
 key_buffer_size = {{ mysql_key_buffer_size | default('256M') }}
 table_open_cache = {{ mysql_table_open_cache | default('256') }}
+log_error = {{ mysql_log_error | default('/dev/stdout') }}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Where:
 * **mysql_max_allowed_packet** is the maximum allowed packet size. Optional, defaults to `64M`.
 * **mysql_table_open_cache** is the table open cache count. Optional, defaults to `256`.
 * **mysql_query_cache_size** is the query cache size to retain. Optional, defaults to `0` as the query cache can be counterproductive for Drupal sites.
+* **mysql_log_error** is the filename to log errors to. Optional, defaults to `/dev/stdout`.
 
 ### Defining databases
 
@@ -125,6 +126,7 @@ flightdeck_cluster:
             mysql_max_allowed_packet: "64M"
             mysql_table_open_cache: "256"
             mysql_query_cache_size: "0"
+            mysql_log_error: "/dev/stdout"
   mysql:
     size: "10Gi"
     secrets:


### PR DESCRIPTION
`mysqld_safe` already logs to stdout, but MySQL error logs do not.
They default to `/var/lib/mysql/mysql-0.err`, where `mysql-0` is the hostname.

This change makes it default to stdout and is configurable.

I haven't tested this; it's not immediately clear how (clone code, push to a private GitLab fork, turn on container registry, build, push to container registry, tell Flight Deck Cluster to pull that?). It's kind of...not worth it for a one-line change—I can always `exec` in and check logs that way—but figured I'd PR this and see where it went or if you randomly had time.